### PR TITLE
Fix sensor not responding on repeated use

### DIFF
--- a/adafruit_shtc3.py
+++ b/adafruit_shtc3.py
@@ -90,8 +90,8 @@ class SHTC3:
 
         self._buffer = bytearray(6)
         self.low_power = False
-        self.reset()
         self.sleeping = False
+        self.reset()
         if self._chip_id & 0x083F != _SHTC3_CHIP_ID:
             raise RuntimeError("Failed to find an ICM20X sensor - check your wiring!")
 
@@ -116,6 +116,7 @@ class SHTC3:
 
     def reset(self):
         """Perform a soft reset of the sensor, resetting all settings to their power-on defaults"""
+        self.sleeping = False
         try:
             self._write_command(_SHTC3_SOFTRESET)
 


### PR DESCRIPTION
Fir for #2  and hopefully #1  as well.

Moved the call to wake to occur before the soft reset command in _init_. Also added a wake call into the reset function in case reset() is used in user code. This will cause 2 wake commands when initialising, but ensures consistent state. Happy to discuss?

Sensor will still be in active state (not low power) until first measurement request. Good idea?