### PR TITLE
Changes on the _chip_id

### DIFF
--- a/adafruit_shtc3.py
+++ b/adafruit_shtc3.py
@@ -107,6 +107,8 @@ class SHTC3:
         self._buffer[0] = _SHTC3_READID >> 8
         self._buffer[1] = _SHTC3_READID & 0xFF
 
+        self.reset()
+
         with self.i2c_device as i2c:
             i2c.write_then_readinto(
                 self._buffer, self._buffer, out_start=0, out_end=2, in_start=0, in_end=2

--- a/adafruit_shtc3.py
+++ b/adafruit_shtc3.py
@@ -118,6 +118,7 @@ class SHTC3:
         self.low_power = False
         self.sleeping = False
         self.reset()
+        self._chip_id = self._get_chip_id()
         if self._chip_id & 0x083F != _SHTC3_CHIP_ID:
             raise RuntimeError("Failed to find an SHTC3 sensor - check your wiring!")
 
@@ -129,18 +130,12 @@ class SHTC3:
         with self.i2c_device as i2c:
             i2c.write(self._buffer, start=0, end=2)
 
-    @property
-    def _chip_id(self):  #   readCommand(SHTC3_READID, data, 3);
+    def _get_chip_id(self):  #   readCommand(SHTC3_READID, data, 3);
         """Determines the chip id of the sensor"""
-        self._buffer[0] = _SHTC3_READID >> 8
-        self._buffer[1] = _SHTC3_READID & 0xFF
-
-        self.reset()
-
+        self._write_command(_SHTC3_READID)
+        time.sleep(0.001)
         with self.i2c_device as i2c:
-            i2c.write_then_readinto(
-                self._buffer, self._buffer, out_start=0, out_end=2, in_start=0, in_end=2
-            )
+            i2c.readinto(self._buffer)
 
         return unpack_from(">H", self._buffer)[0]
 

--- a/adafruit_shtc3.py
+++ b/adafruit_shtc3.py
@@ -119,7 +119,7 @@ class SHTC3:
         self.sleeping = False
         self.reset()
         self._chip_id = self._get_chip_id()
-        if self._chip_id & 0x083F != _SHTC3_CHIP_ID:
+        if self._chip_id != _SHTC3_CHIP_ID:
             raise RuntimeError("Failed to find an SHTC3 sensor - check your wiring!")
 
     def _write_command(self, command):
@@ -137,7 +137,7 @@ class SHTC3:
         with self.i2c_device as i2c:
             i2c.readinto(self._buffer)
 
-        return unpack_from(">H", self._buffer)[0]
+        return unpack_from(">H", self._buffer)[0] & 0x083F
 
     def reset(self):
         """Perform a soft reset of the sensor, resetting all settings to their power-on defaults"""


### PR DESCRIPTION
This is an attempt to solve #8. 
When troubleshooting this, I found two solutions, first is removing the ``@property`` and using the ``_chip_id`` as a normal function.

However this solutions works better as we do not need to change the logic. I found that the problem was when trying to write .
This solve also the problem of resetting the device with the sensor connected as mention in the Adafruit earning guide.

As I cannot figure out why this work, please test, and feel free to reject this PR if this solution is not desired

I test this on

```python
Adafruit CircuitPython 6.2.0-beta.3-188-g05ed179e1 on 2021-03-15; Adafruit Feather RP2040 with rp2040
```